### PR TITLE
Bump the mediawiki LTS version to 1.27.4

### DIFF
--- a/roles/mediawiki/tasks/main.yml
+++ b/roles/mediawiki/tasks/main.yml
@@ -17,8 +17,8 @@
 - name: fetch mediawiki LTS release
   get_url:
     dest: /tmp/
-    url: "https://releases.wikimedia.org/mediawiki/{{mediawiki.release }}/mediawiki-{{ mediawiki.version }}.tar.gz"
-    checksum: "sha256:{{ mediawiki.release_sha256sum }}"
+    url: "https://releases.wikimedia.org/mediawiki/{{mediawiki.version | regex_search("\d+.\d+") }}/mediawiki-{{ mediawiki.version }}.tar.gz"
+    checksum: "sha256:{{ mediawiki.version_sha256sum }}"
   tags:
   - mediawiki
 

--- a/site.yml
+++ b/site.yml
@@ -22,9 +22,8 @@
       database: noisebridge_mediawiki
       database_username: wiki
       domain: noisebridge.net
-      release: 1.27 # needed for URL construction for downloading
-      release_sha256sum: 08a676c392625cf3c5730a6c1b9390ab1e11dcc17cfd0ff97a2ae3917ef5a36a
-      version: 1.27.1
+      version_sha56sum: 6ffac6baacf8a0c999e2d15d24631963efc242b4dab2f632d2614c539eea3976
+      version: 1.27.4
     certbot_certs:
       m3.noisebridge.net:
         - m3.noisebridge.net


### PR DESCRIPTION
Clean up the template that constructs the URL for download using a regex to
extract the minor version number for the URL fragment.