### PR TITLE
Migrate to use top level noisebridge.net domain

### DIFF
--- a/group_vars/noisebridge-net/caddy.yml
+++ b/group_vars/noisebridge-net/caddy.yml
@@ -13,6 +13,12 @@ caddy_config: |
 
     index index.php
 
+    header / {
+      Strict-Transport-Security "max-age=31536000;includeSubdomains"
+      X-XSS-Protection "1; mode=block"
+      X-Content-Type-Options "nosniff"
+    }
+
     fastcgi / unix:/run/php/php7.0-fpm.sock php {
         except /images
     }
@@ -24,6 +30,8 @@ caddy_config: |
   }
 
   noisebridge.net {
+    gzip
+    tls ca@noisebridge.net
     redir https://www.noisebridge.net{uri}
   }
 

--- a/group_vars/noisebridge-net/caddy.yml
+++ b/group_vars/noisebridge-net/caddy.yml
@@ -4,6 +4,11 @@ caddy_setcap: yes
 caddy_systemd_capabilities_enabled: True
 caddy_systemd_capabilities: "CAP_NET_BIND_SERVICE"
 caddy_config: |
+  noisebridge.net {
+    gzip
+    tls ca@noisebridge.net
+    redir https://www.noisebridge.net{uri}
+  }
 
   www.noisebridge.net {
     gzip
@@ -29,10 +34,12 @@ caddy_config: |
     }
   }
 
-  noisebridge.net {
-    gzip
-    tls ca@noisebridge.net
-    redir https://www.noisebridge.net{uri}
+  www.noisebridge.net/pipermail/ {
+    redir https://lists.noisebridge.net{uri}
+  }
+
+  www.noisebridge.net/mailman/ {
+    redir https://lists.noisebridge.net{uri}
   }
 
   lists.noisebridge.net {

--- a/group_vars/noisebridge-net/caddy.yml
+++ b/group_vars/noisebridge-net/caddy.yml
@@ -4,7 +4,8 @@ caddy_setcap: yes
 caddy_systemd_capabilities_enabled: True
 caddy_systemd_capabilities: "CAP_NET_BIND_SERVICE"
 caddy_config: |
-  m3.noisebridge.net {
+
+  www.noisebridge.net {
     gzip
     tls ca@noisebridge.net
 
@@ -22,27 +23,31 @@ caddy_config: |
     }
   }
 
-  lists.m3.noisebridge.net {
+  noisebridge.net {
+    redir https://www.noisebridge.net{uri}
+  }
+
+  lists.noisebridge.net {
     gzip
     tls ca@noisebridge.net
     root /srv/mailman/lists.noisebridge.net
     redir / /mailman/listinfo
   }
 
-  lists.m3.noisebridge.net/mailman/ {
+  lists.noisebridge.net/mailman/ {
     cgi /* /var/lib/mailman/cgi-bin/{match}
 
     redir /mailman /mailman/listinfo
   }
 
-  lists.m3.noisebridge.net/pipermail/ {
+  lists.noisebridge.net/pipermail/ {
     gzip
     tls ca@noisebridge.net
     root /var/lib/mailman/archives/public
     index index.html
   }
 
-  lists.m3.noisebridge.net/images/mailman/ {
+  lists.noisebridge.net/images/mailman/ {
     gzip
     tls ca@noisebridge.net
     root /var/lib/mailman/icons/

--- a/roles/postfix/templates/main.cf
+++ b/roles/postfix/templates/main.cf
@@ -19,8 +19,8 @@ readme_directory = no
 # TLS parameters
 # smtpd_tls_cert_file=/etc/postfix/noisebridge.net-cert.pem
 # smtpd_tls_key_file=/etc/postfix/noisebridge.net-key.pem
-smtpd_tls_cert_file=/etc/ssl/caddy/acme/acme-v01.api.letsencrypt.org/sites/m3.noisebridge.net/m3.noisebridge.net.crt
-smtpd_tls_key_file=/etc/ssl/caddy/acme/acme-v01.api.letsencrypt.org/sites/m3.noisebridge.net/m3.noisebridge.net.key
+smtpd_tls_cert_file=/etc/ssl/caddy/acme/acme-v01.api.letsencrypt.org/sites/noisebridge.net/noisebridge.net.crt
+smtpd_tls_key_file=/etc/ssl/caddy/acme/acme-v01.api.letsencrypt.org/sites/noisebridge.net/noisebridge.net.key
 smtpd_tls_ciphers = high
 smtpd_use_tls=yes
 smtpd_tls_exclude_ciphers = aNULL, MD5, DES, RC4-SHA, AES256-SHA, AES128-SHA

--- a/site.yml
+++ b/site.yml
@@ -24,9 +24,6 @@
       domain: noisebridge.net
       version_sha256sum: 6ffac6baacf8a0c999e2d15d24631963efc242b4dab2f632d2614c539eea3976
       version: 1.27.4
-    certbot_certs:
-      m3.noisebridge.net:
-        - m3.noisebridge.net
 
 - name: List server
   hosts: lists-noisebridge-net


### PR DESCRIPTION
Update caddy, postfix to use the new domain instead of m3.noisebridge.net.

Add a redirect from noisebridge.net to www.noisebridge.net. Add HSTS configuration for www.noisebridge.net which enables it for subdomains also.