### PR TITLE
Temporarily enable the mediawiki debug log

### DIFF
--- a/roles/mediawiki/templates/LocalSettings.php
+++ b/roles/mediawiki/templates/LocalSettings.php
@@ -147,3 +147,5 @@ wfLoadExtension( 'Renameuser' );
 $wgUseGzip = true;
 $wgUseFileCache = false;
 $wgFileCacheDirectory = '/var/cache/mediawiki/';
+
+$wgDebugLogFile = "/tmp/mediawiki-debug.log";


### PR DESCRIPTION
Enable debug logging to help root cause issues with certain thumbnail files on
the installation.