### PR TITLE
Update CoreDNS

### DIFF
--- a/group_vars/primary-dns-server.yml
+++ b/group_vars/primary-dns-server.yml
@@ -4,6 +4,7 @@ coredns_config: |
   noisebridge.net {
     file zones/noisebridge.net {
       transfer to 74.207.242.164 # dns.hexapodia.org
+      transfer to 204.246.122.84 # m2.noisebridge.net
     }
     dnssec noisebridge.net {
       key file keys/Knoisebridge.net.+013+33211
@@ -14,6 +15,7 @@ coredns_config: |
   noisebridge.space {
     file zones/noisebridge.space {
       transfer to 104.131.134.47 # nicias.patrickod.com
+      transfer to 204.246.122.84 # m2.noisebridge.net
       # transfer to 2604:a880:1:20::234:8001 # nicias.patrickod.com
     }
     dnssec noisebridge.space {

--- a/roles/coredns/defaults/main.yml
+++ b/roles/coredns/defaults/main.yml
@@ -2,7 +2,7 @@ coredns_user: coredns
 coredns_port: 53
 
 coredns_path: /srv/coredns
-coredns_version: "1.0.4"
+coredns_version: "1.0.5"
 coredns_download_url: https://github.com/coredns/coredns/releases/download
 
 coredns_config: |

--- a/roles/coredns/tasks/main.yml
+++ b/roles/coredns/tasks/main.yml
@@ -1,8 +1,3 @@
-- name: Install packages
-  apt: pkg={{ item }} state=latest install_recommends=no
-  with_items:
-  - libcap2-bin
-
 - name: Create coredns user
   user:
     name: "{{ coredns_user }}"
@@ -28,6 +23,13 @@
     mode: 0755
     owner: "{{ coredns_user }}"
     copy: no
+  notify:
+  - restart coredns
+
+- name: Set coredns capabilities
+  capabilities:
+    path: "{{ coredns_path }}/coredns"
+    capability: cap_net_bind_service+ep
   notify:
   - restart coredns
 
@@ -62,11 +64,11 @@
   - reload coredns
 
 - name: Install coredns systemd service file
-  notify:
-  - restart coredns
   template:
     src: coredns.service.j2
     dest: /etc/systemd/system/coredns.service
+  notify:
+  - restart coredns
 
 - name: Enable and start coredns service
   systemd:

--- a/roles/coredns/templates/coredns.service.j2
+++ b/roles/coredns/templates/coredns.service.j2
@@ -8,7 +8,6 @@ PermissionsStartOnly=true
 LimitNOFILE=8192
 User=coredns
 WorkingDirectory={{ coredns_path }}
-ExecStartPre=/sbin/setcap cap_net_bind_service=+ep {{ coredns_path }}/coredns
 ExecStart={{ coredns_path }}/coredns -dns.port {{ coredns_port }} -conf {{ coredns_path }}/Corefile -log
 ExecReload=/bin/kill -SIGUSR1 $MAINPID
 Restart=on-failure


### PR DESCRIPTION
* Update version to `1.0.5`.
* Minor syntax consistency.
* Use ansible capabilities controls.
* Remove obsolete need for libcap2-bin.
* Allow DNS transfers to m2.noisebridge.net.
