### PR TITLE
Set autoconfirm variables so we don't instantly autoconfirm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 site.retry
 .vault-password
+.vagrant

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 site.retry
 .vault-password
-.vagrant

--- a/roles/mediawiki/templates/LocalSettings.php
+++ b/roles/mediawiki/templates/LocalSettings.php
@@ -170,3 +170,14 @@ $wgGroupPermissions['autoconfirmed' ]['skipcaptcha'] = true;
 $wgGroupPermissions['emailconfirmed']['skipcaptcha'] = true;
 $wgGroupPermissions['bot'           ]['skipcaptcha'] = true; // registered bots
 $wgGroupPermissions['sysop'         ]['skipcaptcha'] = true;
+
+$wgAutoConfirmCount = 7;
+$wgAutoConfirmAge = 86400*3; // three days
+
+$wgAutopromote = array(
+	"autoconfirmed" => array( "&",
+		array( APCOND_EDITCOUNT, &$wgAutoConfirmCount ),
+		array( APCOND_AGE, &$wgAutoConfirmAge ),
+		APCOND_EMAILCONFIRMED
+	),
+);


### PR DESCRIPTION
Mediawiki uses 0 as the default value for the autoconfirm{age,count} variables instead of a sane default resulting in instant autoconfirming, the opposite of what that group is meant for.