### PR TITLE
Enable Extension:ParserFunctions

### DIFF
--- a/roles/mediawiki/templates/LocalSettings.php
+++ b/roles/mediawiki/templates/LocalSettings.php
@@ -139,6 +139,7 @@ wfLoadSkin( 'Vector' );
 # The following extensions were automatically enabled:
 wfLoadExtension( 'Renameuser' );
 wfLoadExtension( 'Nuke' );
+wfLoadExtension( 'ParserFunctions' );
 wfLoadExtensions([ 'ConfirmEdit', 'ConfirmEdit/ReCaptchaNoCaptcha' ]);
 
 


### PR DESCRIPTION
We used to have this for the #time parser function on the events page: https://www.mediawiki.org/wiki/Help:Extension:ParserFunctions##time

I don't know much about this but Mitch likes it.