### PR TITLE
Add confirmed group to allow bureacrats to manually confirm users.

### DIFF
--- a/roles/mediawiki/templates/LocalSettings.php
+++ b/roles/mediawiki/templates/LocalSettings.php
@@ -182,6 +182,9 @@ $wgGroupPermissions['emailconfirmed']['skipcaptcha'] = true;
 $wgGroupPermissions['bot'           ]['skipcaptcha'] = true; // registered bots
 $wgGroupPermissions['sysop'         ]['skipcaptcha'] = true;
 
+
+$wgGroupPermissions['confirmed' ] = $wgGroupPermissions['autoconfirmed' ];
+
 $wgAutoConfirmCount = 7;
 $wgAutoConfirmAge = 86400*3; // three days
 


### PR DESCRIPTION
Necessary since we can't just add users to the autoconfirmed group.