### PR TITLE
Only autoconfirmed users can create talk pages.

### DIFF
--- a/roles/mediawiki/templates/LocalSettings.php
+++ b/roles/mediawiki/templates/LocalSettings.php
@@ -167,7 +167,10 @@ $wgCaptchaTriggers['badlogin'] = true;
 
 $wgGroupPermissions['*']['createpage'] = false;
 $wgGroupPermissions['user']['createpage'] = false;
+$wgGroupPermissions['*']['createtalk'] = false;
+$wgGroupPermissions['user']['createtalk'] = false;
 $wgGroupPermissions['autoconfirmed' ]['createpage'] = true;
+$wgGroupPermissions['autoconfirmed' ]['createtalk'] = true;
 $wgGroupPermissions['*']['move'] = false;
 $wgGroupPermissions['user']['move'] = false;
 $wgGroupPermissions['autoconfirmed' ]['move'] = true;


### PR DESCRIPTION
90% of the spam I clean up is UserTalk pages. I think this makes it impossible for un-autoconfirmed users to create those, which should reduce the volume.

createtalk is set in DefaultSettings.php here:
https://phabricator.wikimedia.org/source/mediawiki/browse/master/includes/DefaultSettings.php;1ce52c41fcef3cb6fc8dba10ad3a6d570373d8bd$5128

Documentation  of createtalk here:
www.mediawiki.org/wiki/Manual:User_rights#List_of_permissions