### PR TITLE
5 edits for autoconfirmed instead of 7.

### DIFF
--- a/roles/mediawiki/templates/LocalSettings.php
+++ b/roles/mediawiki/templates/LocalSettings.php
@@ -188,7 +188,7 @@ $wgGroupPermissions['sysop'         ]['skipcaptcha'] = true;
 
 $wgGroupPermissions['confirmed' ] = $wgGroupPermissions['autoconfirmed' ];
 
-$wgAutoConfirmCount = 7;
+$wgAutoConfirmCount = 5;
 $wgAutoConfirmAge = 86400*3; // three days
 
 $wgAutopromote = array(


### PR DESCRIPTION
Seems like we might have spam under control. Let's try making the restrictions a little less onerous?