### PR TITLE
Disable SpamAssassin mailman plugin

### DIFF
--- a/roles/mailman/templates/mm_cfg.py.j2
+++ b/roles/mailman/templates/mm_cfg.py.j2
@@ -99,7 +99,7 @@ MTA=None   # Misnomer, suppresses alias output on newlist
 # Uncomment if you want to filter mail with SpamAssassin. For
 # more information please visit this website:
 # http://www.jamesh.id.au/articles/mailman-spamassassin/
-GLOBAL_PIPELINE.insert(1, 'SpamAssassin')
+# GLOBAL_PIPELINE.insert(1, 'SpamAssassin')
 
 # Note - if you're looking for something that is imported from mm_cfg, but you
 # didn't find it above, it's probably in /usr/lib/mailman/Mailman/Defaults.py.


### PR DESCRIPTION
We don't run spamassassin on the mail host anymore.