### PR TITLE
adding mwGoogleSheets

### DIFF
--- a/roles/mediawiki/tasks/main.yml
+++ b/roles/mediawiki/tasks/main.yml
@@ -29,9 +29,9 @@
 
 - name: install mwGoogleSheets extension
   git:
-      repo: 'https://github.com/marcidy/mwGoogleSheet.git'
-      dest: "/src/mediawiki/{{ mediawiki.domain }}/extensions/mwGoogleSheet"
-      version: REL1_27
+    repo: 'https://github.com/marcidy/mwGoogleSheet.git'
+    dest: "/src/mediawiki/{{ mediawiki.domain }}/extensions/mwGoogleSheet"
+    version: REL1_27
   tags:
   - mediawiki
 

--- a/roles/mediawiki/tasks/main.yml
+++ b/roles/mediawiki/tasks/main.yml
@@ -30,7 +30,7 @@
 - name: install mwGoogleSheets extension
   git:
     repo: 'https://github.com/marcidy/mwGoogleSheet.git'
-    dest: "/src/mediawiki/{{ mediawiki.domain }}/extensions/mwGoogleSheet"
+    dest: "/srv/mediawiki/{{ mediawiki.domain }}/extensions/mwGoogleSheet"
     version: REL1_27
   tags:
   - mediawiki

--- a/roles/mediawiki/tasks/main.yml
+++ b/roles/mediawiki/tasks/main.yml
@@ -27,6 +27,14 @@
   tags:
   - mediawiki
 
+- name: install mwGoogleSheets extension
+  git:
+      repo: 'https://github.com/marcidy/mwGoogleSheet.git'
+      dest: "/src/mediawiki/{{ mediawiki.domain }}/extensions/mwGoogleSheet"
+      version: REL1_27
+  tags:
+  - mediawiki
+
 - name: install LocalSettings
   template:
     src: LocalSettings.php

--- a/roles/mediawiki/templates/LocalSettings.php
+++ b/roles/mediawiki/templates/LocalSettings.php
@@ -141,7 +141,7 @@ wfLoadExtension( 'Renameuser' );
 wfLoadExtension( 'Nuke' );
 wfLoadExtension( 'ParserFunctions' );
 wfLoadExtensions([ 'ConfirmEdit', 'ConfirmEdit/ReCaptchaNoCaptcha' ]);
-
+wfLoadExtension( 'mwGoogleSheet' );
 
 # End of automatically generated settings.
 # Add more configuration options below.


### PR DESCRIPTION
this extension is a clone and  update of the original GoogleDocs4MW.  This has the new (working) link format for a shared spreadsheet as part of the generated frame.