### PR TITLE
Enable ip masking for the caddy log files

### DIFF
--- a/group_vars/noisebridge-net/caddy.yml
+++ b/group_vars/noisebridge-net/caddy.yml
@@ -12,6 +12,7 @@ caddy_config: |
       rotate_age 7
       rotate_keep 520
       rotate_compress
+      ipmask 255.255.0.0 ffff:ffff:ffff:ff00::
     }
     tls ca@noisebridge.net
     redir https://www.noisebridge.net{uri}
@@ -25,6 +26,7 @@ caddy_config: |
       rotate_age 7
       rotate_keep 520
       rotate_compress
+      ipmask 255.255.0.0 ffff:ffff:ffff:ff00::
     }
     tls ca@noisebridge.net
     redir https://www.noisebridge.net{uri}
@@ -38,6 +40,7 @@ caddy_config: |
       rotate_age 7
       rotate_keep 520
       rotate_compress
+      ipmask 255.255.0.0 ffff:ffff:ffff:ff00::
     }
     tls ca@noisebridge.net
 
@@ -68,6 +71,7 @@ caddy_config: |
       rotate_age 7
       rotate_keep 520
       rotate_compress
+      ipmask 255.255.0.0 ffff:ffff:ffff:ff00::
     }
     redir https://lists.noisebridge.net{uri}
   }
@@ -79,6 +83,7 @@ caddy_config: |
       rotate_age 7
       rotate_keep 520
       rotate_compress
+      ipmask 255.255.0.0 ffff:ffff:ffff:ff00::
     }
     redir https://lists.noisebridge.net{uri}
   }
@@ -91,6 +96,7 @@ caddy_config: |
       rotate_age 7
       rotate_keep 520
       rotate_compress
+      ipmask 255.255.0.0 ffff:ffff:ffff:ff00::
     }
     tls ca@noisebridge.net
     root /srv/mailman/lists.noisebridge.net
@@ -125,6 +131,7 @@ caddy_config: |
       rotate_age 7
       rotate_keep 520
       rotate_compress
+      ipmask 255.255.0.0 ffff:ffff:ffff:ff00::
     }
     tls ca@noisebridge.net
     root /var/lib/mailman/archives/public
@@ -139,6 +146,7 @@ caddy_config: |
       rotate_age 7
       rotate_keep 520
       rotate_compress
+      ipmask 255.255.0.0 ffff:ffff:ffff:ff00::
     }
     tls ca@noisebridge.net
     root /var/lib/mailman/icons/
@@ -152,6 +160,7 @@ caddy_config: |
       rotate_age 7
       rotate_keep 520
       rotate_compress
+      ipmask 255.255.0.0 ffff:ffff:ffff:ff00::
     }
     tls ca@noisebridge.net
     redir https://www.noisebridge.net{uri}


### PR DESCRIPTION
This should mask IPv4 and IPv6 addresses in the caddy log files.  This does not prevent other applications (e.g. mediawiki) from storing ip address data.  For the values of the mask, I used the values from the caddy [http.log](https://caddyserver.com/docs/log) documentation page since they seemed reasonable.