### PR TITLE
Tweak mediawiki install

### DIFF
--- a/roles/mediawiki/tasks/main.yml
+++ b/roles/mediawiki/tasks/main.yml
@@ -22,6 +22,8 @@
   unarchive:
     src: "/tmp/mediawiki-{{ mediawiki.version }}.tar.gz"
     dest: "/srv/mediawiki/{{ mediawiki.domain }}"
+    owner: root
+    group: root
     remote_src: true
     extra_opts: ["--strip-components=1"]
   tags:
@@ -39,18 +41,19 @@
   template:
     src: LocalSettings.php
     dest: "/srv/mediawiki/{{ mediawiki.domain }}/LocalSettings.php"
-    owner: www-data
+    owner: root
     group: www-data
+    mode: 0640
   tags:
   - mediawiki
   - mediawiki-localsettings
 
 - name: install home page
-  copy:
+  template:
     src: index.html
     dest: "/srv/mediawiki/{{ mediawiki.domain }}/index.html"
     owner: root
     group: root
     mode: 0644
-    tags:
-    - mediawiki
+  tags:
+  - mediawiki

--- a/roles/mediawiki/templates/index.html
+++ b/roles/mediawiki/templates/index.html
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment('xml') }}
 <!DOCTYPE html>
 <html>
   <head>

--- a/site.yml
+++ b/site.yml
@@ -25,8 +25,8 @@
       database: noisebridge_mediawiki
       database_username: wiki
       domain: noisebridge.net
-      version_sha256sum: 6ffac6baacf8a0c999e2d15d24631963efc242b4dab2f632d2614c539eea3976
-      version: 1.27.4
+      version_sha256sum: e2b2b9a68a6640c561dd9edb8fb594b738f8d5d6f97041a032072026460fc071
+      version: 1.27.5
 
 - name: List server
   hosts: lists-noisebridge-net


### PR DESCRIPTION
* Tighten up permissions of LocalSettings.php.
* Change mediawiki file ownership to root.
* Update MediaWiki to latest patch release.
* Add `ansible_managed` templating to index.html.
* Fix up indent of tags on index.html deploy.